### PR TITLE
made twitter iframes render a bit nicer on small devices

### DIFF
--- a/src/pages/episode/index.js
+++ b/src/pages/episode/index.js
@@ -90,7 +90,7 @@ function FutureEpisodeStuff({episodeData, sponsors}) {
               />
             </div>
 
-            <div className="+display-flex +space-children">
+            <div className="twitter-feed-container">
               <TwitterFeed
                 widgetId="675885424049393664"
                 linkTo="https://twitter.com/hashtag/JavaScriptAir"
@@ -114,4 +114,3 @@ function FutureEpisodeStuff({episodeData, sponsors}) {
     </div>
   )
 }
-

--- a/styles.css
+++ b/styles.css
@@ -96,6 +96,22 @@ h3 small {
 }
 
 
+.twitter-timeline-rendered {
+  margin: auto;
+  margin-bottom: 25px !important;
+  display: block !important;
+}
+
+@media only screen and (min-width: 803px) {
+  .twitter-feed-container {
+    display: flex;
+  }
+  .twitter-timeline-rendered {
+    margin-left: 28px;
+    margin-right: 28px;
+  }
+}
+
 /* utilities */
 
 .\+text-center {


### PR DESCRIPTION
This pull request should make the Twitter iframes a bit more legible on smaller devices. 

Note that I removed the utlity classes as they make updating styles from within a media query awkward.

Also note that I added a custom media query, as I felt the breakpoint was unique. 

In a future pull request, I will utilize PostCSS to use vars, mixins, etc. to reduce duplication and improve maintainability, so please don't worry too much about that for this pull request.

Thanks!
