### PR TITLE
add json files generator for episodes, host, panelists and sponsors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ index.html
 styles.dist.css
 *.ignored.*
 npm-debug.log
+data.json

--- a/data/contributors/index.js
+++ b/data/contributors/index.js
@@ -44,6 +44,11 @@ const contributors = [
     twitter: 'about_hiroppy',
     contributions: 'Site PRs',
   },
+  {
+    name: 'Erwan Datin',
+    twitter: 'erwan_datin',
+    contributions: 'Site PRs',
+  },
 ].map(c => {
   return {
     imgSrc: `/data/contributors/${c.twitter}.png`,

--- a/generate/contributors.js
+++ b/generate/contributors.js
@@ -1,20 +1,13 @@
 import {resolve} from 'path'
 import renderComponentToFile from './renderComponentToFile'
 
+import {host} from '../resources/host'
 import sponsors from '../sponsors'
 import contributors from '../data/contributors'
 import {panelists} from '../resources/panelists'
 import {nextEpisode} from '../episodes'
-
 import Contributors from '../src/pages/contributors'
 
-const host = {
-  twitter: 'kentcdodds',
-  link: 'https://twitter.com/kentcdodds',
-  imgSrc: '/resources/kentcdodds.png',
-  name: 'Kent C. Dodds',
-  contributions: 'Host + stuff',
-}
 
 const panelistContributors = panelists.map(p => {
   return {

--- a/generate/json-files-configs/episodes.js
+++ b/generate/json-files-configs/episodes.js
@@ -1,0 +1,13 @@
+export const episodesToJson = {
+  destDirectoryFromHere: '../episodes/',
+  propertiesToFilter: [
+    'numberDisplay',
+    'title',
+    'date',
+    'time',
+    'description',
+    'hangoutId',
+    'youTubeId',
+    'guests',
+  ],
+}

--- a/generate/json-files-configs/host.js
+++ b/generate/json-files-configs/host.js
@@ -1,0 +1,9 @@
+export const hostToJson = {
+  destDirectoryFromHere: '../resources/host/',
+  propertiesToFilter: [
+    'imgSrc',
+    'name',
+    'twitter',
+    'link',
+  ],
+}

--- a/generate/json-files-configs/index.js
+++ b/generate/json-files-configs/index.js
@@ -1,0 +1,11 @@
+import {episodesToJson} from './episodes'
+import {panelistsToJson} from './panelists'
+import {sponsorsToJson} from './sponsors'
+import {hostToJson} from './host'
+
+export {
+  episodesToJson,
+  panelistsToJson,
+  sponsorsToJson,
+  hostToJson,
+}

--- a/generate/json-files-configs/panelists.js
+++ b/generate/json-files-configs/panelists.js
@@ -1,0 +1,9 @@
+export const panelistsToJson = {
+  destDirectoryFromHere: '../resources/panelists/',
+  propertiesToFilter: [
+    'imgSrc',
+    'name',
+    'twitter',
+    'link',
+  ],
+}

--- a/generate/json-files-configs/sponsors.js
+++ b/generate/json-files-configs/sponsors.js
@@ -1,0 +1,9 @@
+export const sponsorsToJson = {
+  destDirectoryFromHere: '../sponsors/',
+  propertiesToFilter: [
+    'premierSponsors',
+    'goldSponsors',
+    'silverSponsors',
+    'appreciationSponsors,',
+  ],
+}

--- a/generate/json-files.js
+++ b/generate/json-files.js
@@ -1,0 +1,29 @@
+import path from 'path'
+import {writeJsonArray, writeJsonObject} from './write-to-json-file'
+import {host} from '../resources/host'
+import {episodes} from '../episodes'
+import {panelists} from '../resources/panelists'
+import sponsors from '../sponsors'
+import * as config from './json-files-configs'
+
+// all episodes data in a same data.json file (filtered properties only)
+writeJsonArray(episodes, config.episodesToJson, true)
+
+// all episodes data in a separate data.json file - per date - (no property filter)
+episodes.forEach(
+  episode => {
+    const episodeConfig = Object.assign({}, config.episodesToJson)
+    episodeConfig.destDirectoryFromHere = path.join(episodeConfig.destDirectoryFromHere, `${episode.date}`)
+    writeJsonObject(episode, episodeConfig)
+  }
+)
+
+// all panelists data in a data.json file (filtered properties only)
+writeJsonArray(panelists, config.panelistsToJson, true)
+
+// all sponsors data in a data.json file (filtered properties only)
+const sponsorsArray = [].concat(sponsors)
+writeJsonArray(sponsorsArray, config.sponsorsToJson, true)
+
+// all host data in a data.json file (no property filter)
+writeJsonObject(host, config.hostToJson, false)

--- a/generate/write-to-json-file.js
+++ b/generate/write-to-json-file.js
@@ -1,0 +1,33 @@
+import path from 'path'
+import fs from 'fs'
+
+export function writeJsonArray(arrayNewItems, config, applyFilter = false) {
+  const DEST_JSON_FILE = path.join(__dirname, config.destDirectoryFromHere, `data.json`)
+  const allFileContent = arrayNewItems.map(item => {
+    return applyFilter ? filterProperties(config.propertiesToFilter, item) : item
+  })
+  writeToFile(DEST_JSON_FILE, JSON.stringify(allFileContent))
+}
+
+export function writeJsonObject(newItem, config, applyFilter = false) {
+  const DEST_JSON_FILE = path.join(__dirname, config.destDirectoryFromHere, `data.json`)
+  const itemToCopy = applyFilter ? filterProperties(config.propertiesToFilter, newItem) : newItem
+  writeToFile(DEST_JSON_FILE, JSON.stringify(itemToCopy))
+}
+
+function writeToFile(file, content) {
+  fs.writeFile(file, content, err => {
+    if (err) {
+      process.stdout.write(`😱ERROR: could not write json file: ${file}\n->Error details: ${err}\n`)
+      process.exit(1)
+    }
+  })
+}
+
+function filterProperties(listProps, object) {
+  const filtered = {}
+  listProps.forEach(property => {
+    filtered[property] = object[property]
+  })
+  return filtered
+}

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -7,7 +7,7 @@ module.exports = {
     build: {
       default: {
         description: 'Runs all the build scripts in parallel',
-        script: 'p-s -p eslint,build.home,build.episodes,build.guests,build.deals,build.css,build.contributors',
+        script: 'p-s -p eslint,build.home,build.episodes,build.guests,build.deals,build.css,build.contributors,createJson.script',
       },
       home: 'babel-node generate/home',
       episodes: './scripts/build-episodes.sh',
@@ -47,6 +47,10 @@ module.exports = {
     addContributor: {
       description: 'Similar to add guest except this is specific to adding contributors',
       script: 'babel-node ./other/add-contributor',
+    },
+    createJson: {
+      description: 'Create JSON data of episodes, panelists, host and sponsors',
+      script: 'babel-node generate/json-files',
     },
     dev: {
       default: {

--- a/resources/host/index.js
+++ b/resources/host/index.js
@@ -1,0 +1,7 @@
+export const host = {
+  twitter: 'kentcdodds',
+  link: 'https://twitter.com/kentcdodds',
+  imgSrc: '/resources/kentcdodds.png',
+  name: 'Kent C. Dodds',
+  contributions: 'Host + stuff',
+}


### PR DESCRIPTION
## Content
#### Add JSON files generator for:
- episodes
- host
- panelists
- sponsors

Files are created/updated in **/data/json** directory.

> NOTE: 
> - **/data/json** directory must exist (_generator does not test it since it should_)
> - files could not exist or be empty 
>   - it won't matter generator will do its job
> - generator sources
>   - **generate/jsonFiles.js**
>   - **generate/writeToJsonFile.js**
>     ## task 
#### JSON generator only

`npm run build:json`
#### all validate task

`npm run validate`
## Bonus

I needed to import host data (previsouly created on the fly in **/generate/contributors**).
So host data is now in **/ressources/host/index.js** (_I updated /generate/contributors by the way_)
## To finish

Something else is coming soon...
