### PR TITLE
switch to uniqBy to remove duplicate guests

### DIFF
--- a/generate/guests.js
+++ b/generate/guests.js
@@ -1,17 +1,17 @@
 import {resolve} from 'path'
 import renderComponentToFile from './renderComponentToFile'
 
-import {flatten, uniq} from 'lodash'
+import {flatten, uniqBy} from 'lodash'
 
 import {episodes} from '../episodes'
 import Guests from '../src/pages/guests'
 import {sortPeople} from '<utils>/utils'
 
 const guests = sortPeople(
-  uniq(
+  uniqBy(
     flatten(episodes.map(e => e.guests))
       .filter(g => g.name !== 'TBA'),
-    g => (g.twitter || g.name)
+   'twitter'
   )
 )
 


### PR DESCRIPTION
Current live site is duplicating guest thumbs.  I believe this pull request should fix that.

Current LIve Screen from - https://javascriptair.com/guests/ 
![screen shot 2016-05-30 at 3 57 13 pm](https://cloud.githubusercontent.com/assets/62242/15657483/41c7be0a-267f-11e6-961b-614c6e237a76.png)
