### PR TITLE
Raise default font weight

### DIFF
--- a/resources/css/aphrodite-shortcomings.css
+++ b/resources/css/aphrodite-shortcomings.css
@@ -5,7 +5,6 @@ body {
   font-family: 'Josefin Sans', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  font-weight: 300;
 }
 *, :before, :after {box-sizing: border-box;}
 strong {font-weight: bold;}


### PR DESCRIPTION
A font weight of 300 causes extremely thin fonts that hurt accessibility, even if the colour combination would be considered accessible with a more conservative font choice.

This is to address #118, but doesn't solve it completely.
