### PR TITLE
fix(a11y): color-contrast as per AAA guidelines

### DIFF
--- a/src/pages/home/sections/episodes/episode-small.js
+++ b/src/pages/home/sections/episodes/episode-small.js
@@ -74,7 +74,7 @@ EpisodeSmall.styles = StyleSheet.create({
   guests: {
     fontSize: '0.9em',
     lineHeight: '1.3',
-    color: 'gray',
+    color: '#4a4a4a',
     [upToBig]: {
       fontSize: '1.2em',
       paddingTop: 10,
@@ -83,7 +83,7 @@ EpisodeSmall.styles = StyleSheet.create({
     },
   },
   guestsAnchor: {
-    color: 'gray',
+    color: '#4a4a4a',
     ':hover': {
       color: 'black',
     },


### PR DESCRIPTION
for episodes guest links and text

<img width="1280" alt="screen_shot_2016-06-15_at_5_29_33_pm" src="https://cloud.githubusercontent.com/assets/949380/16101905/4e1b73a2-331f-11e6-86f5-4cf45b02b11d.png">

fixes #118
