### PR TITLE
Remove unused styles in legacy css. For #126

### DIFF
--- a/resources/css/legacy.css
+++ b/resources/css/legacy.css
@@ -51,13 +51,6 @@
       margin-top: 34px;
       margin-bottom: 34px;
     }
-    .\+space-children>* {
-      margin-left: 10px;
-      margin-right: 10px;
-    }
-    .\+font-smaller {
-      font-size: 12px;
-    }
     hr.person-note-separator {
       margin-top: 20px;
       margin-bottom: 20px;
@@ -78,13 +71,6 @@
     hr {
       margin-top: 70px;
       margin-bottom: 70px;
-    }
-    .\+space-children>* {
-      margin-left: 28px;
-      margin-right: 28px;
-    }
-    .\+font-smaller {
-      font-size: 18px;
     }
     hr.person-note-separator {
       margin-top: 36px;

--- a/resources/css/legacy.css
+++ b/resources/css/legacy.css
@@ -51,6 +51,10 @@
       margin-top: 34px;
       margin-bottom: 34px;
     }
+    .\+space-children>* {
+      margin-left: 10px;
+      margin-right: 10px;
+    }
     hr.person-note-separator {
       margin-top: 20px;
       margin-bottom: 20px;
@@ -71,6 +75,10 @@
     hr {
       margin-top: 70px;
       margin-bottom: 70px;
+    }
+    .\+space-children>* {
+      margin-left: 28px;
+      margin-right: 28px;
     }
     hr.person-note-separator {
       margin-top: 36px;

--- a/src/components/sponsors/sponsor-group.js
+++ b/src/components/sponsors/sponsor-group.js
@@ -22,7 +22,7 @@ function SponsorGroup({sponsors, title}) {
       {
         chunkedSponsors.map((rowSponsors, index) => {
           return (
-            <div className={`${css(styles.group)} +space-children`} key={index}>
+            <div className={css(styles.group)} key={index}>
               {rowSponsors.map((s, i) => <Sponsor key={i} {...s} />)}
             </div>
           )

--- a/src/pages/episode/sections/show-notes/person-notes.js
+++ b/src/pages/episode/sections/show-notes/person-notes.js
@@ -18,7 +18,7 @@ function PersonNotes({person}) {
   const personClassNames = {root: css(styles.personRoot)}
 
   return (
-    <div className={css(styles.personNotes)}>
+    <div className={`${css(styles.personNotes)} +space-children`}>
       <Person {...person} personClassNames={personClassNames} />
       {
         nothing ?

--- a/src/pages/episode/sections/show-notes/person-notes.js
+++ b/src/pages/episode/sections/show-notes/person-notes.js
@@ -17,7 +17,7 @@ function PersonNotes({person}) {
   const personClassNames = {root: css(styles.personRoot)}
 
   return (
-    <div className={`${css(styles.personNotes)} +space-children`}>
+    <div className={css(styles.personNotes)}>
       <Person {...person} personClassNames={personClassNames} />
       {
         nothing ?


### PR DESCRIPTION
Unused styles removed from legacy.css (all the other styles except these two are being used at least once).
- +space-children appears in episodes page but is not used
- +font-smaller isn't used anywhere in the site

Migrating to aphrodite shouldn't be too difficult. In all of the pages where the styles appear, the .container class is enclosing and there's not many styles to reference. Just need to replicate the styles in-line for each of the pages then we can remove legacy.css :+1: 
