### PR TITLE
Make links, tips and picks responsive. Closes #129

### DIFF
--- a/src/pages/episode/sections/show-notes/person-notes.js
+++ b/src/pages/episode/sections/show-notes/person-notes.js
@@ -1,5 +1,6 @@
 import {PropTypes} from 'react'
 import {StyleSheet, css} from 'aphrodite'
+import {upToSmall, upToMedium} from '<styles>/media-queries'
 
 import Person from '<components>/person'
 
@@ -43,11 +44,14 @@ PersonNotes.propTypes = {
 PersonNotes.styles = StyleSheet.create({
   personNotes: {
     display: 'flex',
+    [upToMedium]: {
+      flexDirection: 'column',
+    },
   },
   notesContainer: {flex: 1},
   personRoot: {
     minWidth: 220,
-    '@media only screen and (max-width: 500px)': {
+    [upToSmall]: {
       minWidth: 150,
     },
   },
@@ -80,6 +84,7 @@ Notes.propTypes = {
 Notes.styles = StyleSheet.create({
   list: {
     listStyle: 'disc',
-    paddingLeft: 40,
+    padding: '10px 0px 10px 40px',
+    lineHeight: '1.2em',
   },
 })


### PR DESCRIPTION
## Added some padding and line-height to the list as well make it look a bit better.

Big:
## ![laptop](https://cloud.githubusercontent.com/assets/12476932/16173506/0767c312-3571-11e6-86a8-c87538cb5803.PNG)

Medium:
## ![tablet](https://cloud.githubusercontent.com/assets/12476932/16173511/1464e86a-3571-11e6-81d1-0c8a857e0ab8.PNG)

Mobile:
![mobile](https://cloud.githubusercontent.com/assets/12476932/16173513/1a6661bc-3571-11e6-8151-6f893cef5547.PNG)
