### PR TITLE
Add 'word-wrap: break-word' style to episode notes

### DIFF
--- a/src/pages/episode/sections/show-notes/person-notes.js
+++ b/src/pages/episode/sections/show-notes/person-notes.js
@@ -50,6 +50,7 @@ PersonNotes.styles = StyleSheet.create({
   },
   notesContainer: {
     flex: 1,
+    'word-break': 'break-word',
     [upToMediumBig]: {
       marginLeft: '10',
       marginRight: '10',


### PR DESCRIPTION
Solves the issue of long links overflowing the mobile viewport
